### PR TITLE
Switching to github pages for out-of-the-box deploys

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,42 +1,9 @@
 /* jshint node: true */
 
-var AWS = require('aws-sdk');
-var _ = require('lodash');
 
 module.exports = function(deployTarget) {
-  var credentials = AWS.config.keys.credentials();
-  if (!credentials.secretAccessKey) {
-    throw new Error("Unable to find AWS credentials. ");
-  }
-
-  var s3CommonOptions = {
-    accessKeyId: credentials.accessKeyId,
-    secretAccessKey: credentials.secretAccessKey,
-    region: 'us-east-1',
-    bucket: 'appcache-demo.eaf4.com'
-  };
-
   var ENV = {
     build: {},
-    plugins: ['appshell', 'build', 'display-revisions', 'manifest', 'revision-data', 's3', 's3-index', 's3-index:s3-index-manifest', 's3-index:s3-index-appshell'],
-
-    s3: _.defaults({
-      filePattern: '**/*.{js,css,png,gif,ico,jpg,jpeg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,ttc,csv}'
-    }, s3CommonOptions),
-
-    's3-index': _.defaults({
-      allowOverwrite: true
-    }, s3CommonOptions),
-
-    's3-index-manifest': _.defaults({
-      filePattern: 'manifest.appcache',
-      allowOverwrite: true
-    }, s3CommonOptions),
-
-    's3-index-appshell': _.defaults({
-      filePattern: 'appshell.html',
-      allowOverwrite: true
-    }, s3CommonOptions),
 
     appshell: {
       excludePattern: '{robots.txt,crossdomain.xml}',

--- a/config/environment.js
+++ b/config/environment.js
@@ -40,7 +40,9 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    // for deployment to Github Pages
+    ENV.locationType = 'hash';
+    ENV.baseURL = '/ember-appcache-demo/';
   }
 
   return ENV;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "aws-sdk": "^2.2.47",
     "broccoli-asset-rev": "^2.2.0",
     "broccoli-filter": "^1.2.3",
     "ember-ajax": "0.7.1",
@@ -28,13 +27,9 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-deploy": "0.6.0",
-    "ember-cli-deploy-appshell": "0.1.0",
+    "ember-cli-deploy-appshell": "0.2.0",
     "ember-cli-deploy-build": "0.1.1",
-    "ember-cli-deploy-display-revisions": "0.1.2",
-    "ember-cli-deploy-manifest": "0.1.1",
-    "ember-cli-deploy-revision-data": "0.1.1",
-    "ember-cli-deploy-s3": "0.2.1",
-    "ember-cli-deploy-s3-index": "0.3.1",
+    "ember-cli-deploy-git": "^0.1.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
@@ -46,9 +41,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
-    "ember-resolver": "^2.0.3",
-    "htmlparser2": "^3.9.0",
-    "lodash": "^4.6.1"
+    "ember-resolver": "^2.0.3"
   },
   "ember-addon": {
     "paths": []


### PR DESCRIPTION
This switches to `ember-cli-deploy-git` for deployment. By default, it will target the branch `gh-pages` on your `origin` remote. The only prerequisite is making sure that branch exists.
