### PR TITLE
Fix recompute of "interested" buttons for talks with ID containing comma(s)

### DIFF
--- a/app/components/is-interested-button.js
+++ b/app/components/is-interested-button.js
@@ -8,16 +8,22 @@ export default Ember.Component.extend({
 
   interests: storageFor('interests'),
 
+  // Need to remove commas from the key b/c of
+  // github.com/emberjs/ember.js/blob/v2.4.0/packages/ember-metal/lib/expand_properties.js#L48-L52
+  storageKey: Ember.computed('talkId', function() {
+    return this.get('talkId').replace(/,/g, '');
+  }),
+
   didReceiveAttrs() {
     this._super(...arguments);
-    this.checked = Ember.computed(`interests.${this.get('talkId')}`, function() {
-      return this.getWithDefault(`interests.${this.get('talkId')}`, false);
+    this.checked = Ember.computed(`interests.${this.get('storageKey')}`, function() {
+      return this.getWithDefault(`interests.${this.get('storageKey')}`, false);
     });
   },
 
   checked: null,
 
   click() {
-    this.toggleProperty(`interests.${this.get('talkId')}`);
+    this.toggleProperty(`interests.${this.get('storageKey')}`);
   }
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -135,10 +135,13 @@ header .logo.reveal:after {
     margin-top: 0.75em;
 }
 
+<<<<<<< HEAD
 ::-webkit-scrollbar {
   display: none;
 }
 
+=======
+>>>>>>> Add "interested in" button, saves to local storage
 p + .is-interested-button {
     margin-top: 4px;
 }
@@ -147,7 +150,7 @@ h3 + .is-interested-button {
     margin-top: 8px;
 }
 
-.is-interested-button.nope {
+.is-interested-button.nope:not(:hover) {
     background-color: lightblue;
 }
 


### PR DESCRIPTION
Removes commas from the storage key. This fixes updating of buttons for talks with an ID that contains one or more commas. Apparently, commas are split upon by internal CP logic. Who knew? ¯_(ツ)_/¯

Also, provides hover state for falsy "interested" buttons by not overriding their style.
